### PR TITLE
Fix the appearance on the default variable from html

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -80,7 +80,7 @@ inputs:
       title: "Build number to stamp on the icon"
       summary: Build number to stamp on the icon
       description: |
-        Build number to stamp on the icon. Defaults to BITRISE_BUILD_NUMBER
+        Build number to stamp on the icon. Defaults to `BITRISE_BUILD_NUMBER`
       is_expand: true
       is_required: true
       value_options: []


### PR DESCRIPTION
Hi, @ollitapa 

I found to see wrong appearance the default value on your step.

<img width="1094" alt="screenshot 273" src="https://user-images.githubusercontent.com/22558921/66885006-f6f4f300-f00d-11e9-9850-cd32c6affd19.png">

The PR is adapted the official step; e.g. below step

<img width="1096" alt="screenshot 272" src="https://user-images.githubusercontent.com/22558921/66885070-23a90a80-f00e-11e9-9dde-003dbc0e5924.png">

